### PR TITLE
Don't check for "notranslate" CSS class

### DIFF
--- a/docs/src/about.rst
+++ b/docs/src/about.rst
@@ -72,7 +72,7 @@ a bug, which you can report on `GitHub
 If third-party code blocks are in use, matching may fail because of
 inconsistent or unrecognised CSS classes. The class related to the block lexer
 name is automatically added to the list of CSS classes that are searched when
-matching code examples as ``highlight-{lexer} notranslate``.
+matching code examples as ``highlight-{lexer}``.
 If the class has another value, :confval:`codeautolink_search_css_classes`
 can be used to extend the search. To find out which classes should be added,
 build your documentation, locate the code example and use the class of the
@@ -80,7 +80,7 @@ outermost ``div`` tag. For example:
 
 .. code:: python
 
-   codeautolink_search_css_classes = ["highlight-default notranslate"]
+   codeautolink_search_css_classes = ["highlight-default"]
 
 Secondly, matching can fail on a specific line or range of lines.
 This is often a bug, but the known expected failure cases are presented here:

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,6 +11,7 @@ sphinx-codeautolink adheres to
 Unreleased
 ----------
 - Correctly test for optional types in annotations (:issue:`72`)
+- Don't check for ``notranslate`` CSS class, allow additional classes (:issue:`75`)
 
 0.7.0 (2021-11-28)
 ------------------

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -231,7 +231,7 @@ def link_html(
     soup = BeautifulSoup(text, 'html.parser')
 
     block_types = {'python', 'pycon'} | set(custom_blocks.keys())
-    classes = [f'highlight-{t} notranslate' for t in block_types] + ['doctest']
+    classes = [f'highlight-{t}' for t in block_types] + ['doctest']
     classes += search_css_classes
 
     blocks = []


### PR DESCRIPTION
First of all, thanks a lot for this great extension!

I would like to use this together with my own extension (https://nbsphinx.readthedocs.io), and I think I made it work after a small modification (https://github.com/spatialaudio/nbsphinx/pull/613), but there are still a few things that could be implemented to make it easier to use (by means of requiring less intricate configuration).

So my first question is: Is it really necessary to check for the `notranslate` CSS class?

Having two classes in the query string seems to make BeautifulSoup check for the exact string, which means that code blocks with additional classes (defined by the user or by other extensions) will not be supported.

For example, one could want to write something like this:

```rst
.. rst-class:: my-fancy-style

.. code:: python

    import my_module
```

... which leads to HTML output like this:

```html
<div class="my-fancy-style highlight-python notranslate">
```

... which will not be parsed by `sphinx-codeautolink`!

With this PR, it will be parsed as expected.

---

- [ ] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
