### PR TITLE
Automatic support for ipython3 code blocks

### DIFF
--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -211,6 +211,27 @@ However, any test setup and teardown code is not taken into account.
    >>> import lib
    >>> lib.Knight()
 
+IPython code blocks
+-------------------
+Code blocks using the language setting ``ipython3`` are supported by default.
+The function :func:`~sphinx_codeautolink.clean_ipython` is used to handle
+IPython-specific syntax like so-called `magic functions`_.
+
+.. _magic functions: https://ipython.readthedocs.io/en/stable/
+   interactive/tutorial.html#magic-functions
+
+.. code-block:: ipython3
+
+   %reset
+   import lib
+   lib.Knight().taunt()
+
+This is useful for integrating Jupyter notebooks, which is possible with
+separate Sphinx extensions like nbsphinx_ or MyST-NB_.
+
+.. _nbsphinx: https://nbsphinx.readthedocs.io/
+.. _MyST-NB: https://myst-nb.readthedocs.io/
+
 Third-party code blocks
 -----------------------
 Third-party code blocks that use the basic Pygments lexers for Python

--- a/docs/src/reference.rst
+++ b/docs/src/reference.rst
@@ -111,9 +111,12 @@ CSS class
 ---------
 The CSS class used in all code block links is ``sphinx-codeautolink-a``.
 
-Cleanup function
-----------------
-The function below is usable for cleaning ``pycon`` code blocks.
-It is intended to be used with :confval:`codeautolink_custom_blocks`.
+Cleanup functions
+-----------------
+The functions below are usable for cleaning
+``pycon`` and ``iypthon`` code blocks.
+They are intended to be used with :confval:`codeautolink_custom_blocks`.
 
 .. autofunction:: sphinx_codeautolink.clean_pycon
+
+.. autofunction:: sphinx_codeautolink.clean_ipython

--- a/docs/src/reference.rst
+++ b/docs/src/reference.rst
@@ -114,7 +114,7 @@ The CSS class used in all code block links is ``sphinx-codeautolink-a``.
 Cleanup functions
 -----------------
 The functions below are usable for cleaning
-``pycon`` and ``iypthon`` code blocks.
+``pycon`` and ``ipython`` code blocks.
 They are intended to be used with :confval:`codeautolink_custom_blocks`.
 
 .. autofunction:: sphinx_codeautolink.clean_pycon

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -15,6 +15,7 @@ Unreleased
   (:issue:`75`)
 - Allow to specify block parsers as importable references (:issue:`76`)
 - Correctly produce links for ``py`` code blocks (:issue:`81`)
+- Automatic support for ``ipython3`` code blocks (:issue:`79`)
 
 0.7.0 (2021-11-28)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ extras_require = {
         "pydocstyle[toml]>=6.1",
         "pygments",
     ],
+    "ipython": [
+        "ipython",
+    ],
 }
 extras_require["dev"] = sum(extras_require.values(), [])
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras_require = {
         "doc8>=0.9",
         "flake8",
         "flake8-bugbear",
+        "ipython",
         "pydocstyle[toml]>=6.1",
         "pygments",
     ],

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extras_require = {
     "tests": [
         "pytest>=6",
         "coverage[toml]>=5",
+        "ipython",
     ],
     "checks": [
         "tox",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ extras_require = {
     ],
     "docs": [
         "sphinx-rtd-theme",
-        "matplotlib"
+        "matplotlib",
+        "ipython",
     ],
     "tests": [
         "pytest>=6",

--- a/src/sphinx_codeautolink/__init__.py
+++ b/src/sphinx_codeautolink/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path as _Path
 
 from sphinx.application import Sphinx
 from .extension import backref, directive, SphinxCodeAutoLink
-from .extension.block import clean_pycon  # NOQA
+from .extension.block import clean_pycon, clean_ipython  # NOQA
 
 _version_file = _Path(_os.path.realpath(__file__)).parent / "VERSION"
 __version__ = _version_file.read_text().strip()

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -91,7 +91,7 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
         self.global_preface = global_preface
         self.transformers = BUILTIN_BLOCKS.copy()
         self.transformers.update(custom_blocks)
-        self.valid_blocks = self.custom_blocks.keys()
+        self.valid_blocks = self.transformers.keys()
         self.title_stack = []
         self.current_refid = None
         self.prefaces = []
@@ -178,7 +178,7 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
             return
 
         source = node.children[0].astext()
-        transformer = self.custom_blocks[language]
+        transformer = self.transformers[language]
         if transformer:
             source, clean_source = transformer(source)
         else:

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -14,7 +14,10 @@ from .backref import CodeExample
 from .directive import ConcatMarker, PrefaceMarker, SkipMarker
 
 
-BUILTIN_BLOCKS = {}
+BUILTIN_BLOCKS = {
+    'python': None,
+    'py': None,
+}
 
 
 @dataclass
@@ -32,15 +35,6 @@ class ParsingError(Exception):
 
 class UserError(Exception):
     """Error in sphinx-autocodelink usage."""
-
-
-def default_transform(source):
-    """Transform Python code with a no-op."""
-    return source, source
-
-
-BUILTIN_BLOCKS['python'] = default_transform
-BUILTIN_BLOCKS['py'] = default_transform
 
 
 def clean_pycon(source: str) -> Tuple[str, str]:
@@ -184,8 +178,11 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
             return
 
         source = node.children[0].astext()
-        transformer = self.custom_blocks.get(language) or default_transform
-        source, clean_source = transformer(source)
+        transformer = self.custom_blocks.get(language)
+        if transformer:
+            source, clean_source = transformer(source)
+        else:
+            clean_source = source
         example = CodeExample(
             self.current_document, self.current_refid, list(self.title_stack)
         )

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -89,8 +89,8 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
         relative_path = Path(self.document['source']).relative_to(source_dir)
         self.current_document = str(relative_path.with_suffix(''))
         self.global_preface = global_preface
-        self.custom_blocks = BUILTIN_BLOCKS
-        self.custom_blocks.update(custom_blocks)
+        self.transformers = BUILTIN_BLOCKS.copy()
+        self.transformers.update(custom_blocks)
         self.valid_blocks = self.custom_blocks.keys()
         self.title_stack = []
         self.current_refid = None

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -178,7 +178,7 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
             return
 
         source = node.children[0].astext()
-        transformer = self.custom_blocks.get(language)
+        transformer = self.custom_blocks[language]
         if transformer:
             source, clean_source = transformer(source)
         else:

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -40,6 +40,7 @@ def default_transform(source):
 
 
 BUILTIN_BLOCKS['python'] = default_transform
+BUILTIN_BLOCKS['py'] = default_transform
 
 
 def clean_pycon(source: str) -> Tuple[str, str]:
@@ -96,7 +97,7 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
         self.global_preface = global_preface
         self.custom_blocks = BUILTIN_BLOCKS
         self.custom_blocks.update(custom_blocks)
-        self.valid_blocks = ('py',) + tuple(self.custom_blocks.keys())
+        self.valid_blocks = self.custom_blocks.keys()
         self.title_stack = []
         self.current_refid = None
         self.prefaces = []

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -53,6 +53,12 @@ def clean_pycon(source: str) -> Tuple[str, str]:
     return source, '\n'.join(clean_lines)
 
 
+def clean_ipython(source: str) -> Tuple[str, str]:
+    """Clean up IPython syntax to pure Python."""
+    from IPython.core.inputtransformer2 import TransformerManager
+    return source, TransformerManager().transform_cell(source)
+
+
 class CodeBlockAnalyser(nodes.SparseNodeVisitor):
     """Transform literal blocks of Python with links to reference documentation."""
 
@@ -70,7 +76,10 @@ class CodeBlockAnalyser(nodes.SparseNodeVisitor):
         relative_path = Path(self.document['source']).relative_to(source_dir)
         self.current_document = str(relative_path.with_suffix(''))
         self.global_preface = global_preface
-        self.custom_blocks = {'pycon': clean_pycon}
+        self.custom_blocks = {
+            'pycon': clean_pycon,
+            'ipython3': clean_ipython,
+        }
         self.custom_blocks.update(custom_blocks)
         self.valid_blocks = ('py', 'python') + tuple(self.custom_blocks.keys())
         self.title_stack = []
@@ -230,7 +239,7 @@ def link_html(
     text = document.read_text('utf-8')
     soup = BeautifulSoup(text, 'html.parser')
 
-    block_types = {'python', 'py', 'pycon'} | set(custom_blocks.keys())
+    block_types = {'python', 'py', 'pycon', 'ipython3'} | set(custom_blocks.keys())
     classes = [f'highlight-{t}' for t in block_types] + ['doctest']
     classes += search_css_classes
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,3 +7,6 @@ class TestPackage:
 
     def test_clean_pycon_public(self):
         assert sphinx_codeautolink.clean_pycon
+
+    def test_clean_ipython_public(self):
+        assert sphinx_codeautolink.clean_ipython

--- a/tests/extension/ref/ref_ipython.txt
+++ b/tests/extension/ref/ref_ipython.txt
@@ -1,0 +1,14 @@
+test_project
+test_project.bar
+# split
+# split
+Test project
+============
+
+.. code:: ipython3
+
+   %cd subdir
+   import test_project
+   test_project.bar()
+
+.. automodule:: test_project


### PR DESCRIPTION
My main goal is to use this extension together with https://nbsphinx.readthedocs.io/ and to make it as easy as possible for others to do so as well.

#75 already helped to avoid having to specify custom CSS classes and this PR avoids having to specify `codeautolink_custom_blocks`.

For reference, here are some changes on the `nbsphinx` side:
https://github.com/spatialaudio/nbsphinx/pull/613
https://github.com/spatialaudio/nbsphinx/pull/614

With those changes in place, the only thing that users have to do is to add `'sphinx_codeautolink'` to `extensions`. And that's exactly the amount they *should* have to do (i.e. I don't want to enable it automatically when loading `nbsphinx`).

----

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
