### PR TITLE
DOC: use a string in the clean_pycon() usage example

### DIFF
--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -195,13 +195,14 @@ is provided as a ready-made transformer.
 
 .. code:: python
 
-   from sphinx_codeautolink import clean_pycon
-
    extensions = [
        ...,
        "sphinx.ext.doctest",
    ]
-   codeautolink_custom_blocks = {"python3": None, "pycon3": clean_pycon}
+   codeautolink_custom_blocks = {
+       "python3": None,
+       "pycon3": "sphinx_codeautolink.clean_pycon",
+   }
 
 ``doctest`` and ``testcode`` blocks now work as expected.
 However, any test setup and teardown code is not taken into account.


### PR DESCRIPTION
Since 351c2f6ef70e0221da6d4dc1162ddcc7455d1368 I would consider specifying a string the recommended usage, since this will not break Sphinx's caching mechanism (see #76).