### PR TITLE
Declare parallel_read_safe

### DIFF
--- a/docs/src/about.rst
+++ b/docs/src/about.rst
@@ -47,8 +47,10 @@ Caveats
   on the expected failures, see our `test suite on GitHub <https://github.com
   /felix-hilden/sphinx-codeautolink>`_. Please report any unexpected failures!
 
-Clean Sphinx build
-------------------
+Sphinx semantics
+----------------
+Clean build
+***********
 For correct partial builds, code reference information is saved to a file
 which is updated when parsing new or outdated files.
 It shouldn't become outdated, but a clean build can be achieved with
@@ -56,10 +58,16 @@ It shouldn't become outdated, but a clean build can be achieved with
 #cmdoption-sphinx-build-E>`_ or by deleting the build directory.
 
 Sphinx cache
-------------
+************
 A function specified in :confval:`codeautolink_custom_blocks` prevents Sphinx
 from caching documentation results. Consider using an importable instead.
 For more information, see the discussion in :issue:`76`.
+
+Parallel build and custom parsers
+*********************************
+Locally defined custom block parsers in :confval:`codeautolink_custom_blocks`
+cannot be passed to Pickle, which prevents parallel Sphinx builds.
+Please consider using an importable function instead.
 
 Copying code blocks
 -------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -16,6 +16,7 @@ Unreleased
 - Allow to specify block parsers as importable references (:issue:`76`)
 - Correctly produce links for ``py`` code blocks (:issue:`81`)
 - Automatic support for ``ipython3`` code blocks (:issue:`79`)
+- Allow parallel builds (:issue:`77`)
 
 0.7.0 (2021-11-28)
 ------------------

--- a/src/sphinx_codeautolink/__init__.py
+++ b/src/sphinx_codeautolink/__init__.py
@@ -29,6 +29,8 @@ def setup(app: Sphinx):
     app.connect('builder-inited', state.build_inited)
     app.connect('autodoc-process-docstring', state.autodoc_process_docstring)
     app.connect('doctree-read', state.parse_blocks)
+    app.connect('env-merge-info', state.merge_environments)
+    app.connect('env-purge-doc', state.purge_doc_from_environment)
     app.connect('env-updated', state.create_references)
     app.connect('doctree-resolved', state.generate_backref_tables)
     app.connect('build-finished', state.apply_links)
@@ -39,4 +41,4 @@ def setup(app: Sphinx):
     app.add_node(
         backref.SummaryNode, html=(backref.visit_summary, backref.depart_summary)
     )
-    return {'version': __version__}
+    return {'version': __version__, 'parallel_read_safe': True}

--- a/src/sphinx_codeautolink/__init__.py
+++ b/src/sphinx_codeautolink/__init__.py
@@ -29,6 +29,7 @@ def setup(app: Sphinx):
     app.connect('builder-inited', state.build_inited)
     app.connect('autodoc-process-docstring', state.autodoc_process_docstring)
     app.connect('doctree-read', state.parse_blocks)
+    app.connect('env-updated', state.create_references)
     app.connect('doctree-resolved', state.generate_backref_tables)
     app.connect('build-finished', state.apply_links)
 

--- a/src/sphinx_codeautolink/extension/__init__.py
+++ b/src/sphinx_codeautolink/extension/__init__.py
@@ -85,6 +85,7 @@ class SphinxCodeAutoLink:
 
         self.cache = DataCache(app.doctreedir, app.srcdir)
         self.cache.read()
+        app.env.sphinx_codeautolink_transforms = self.cache.transforms
         self.outdated_docs = {str(Path(d)) for d in app.builder.get_outdated_docs()}
         self.custom_blocks = app.config.codeautolink_custom_blocks
         for k, v in self.custom_blocks.items():
@@ -128,6 +129,18 @@ class SphinxCodeAutoLink:
         )
         doctree.walkabout(visitor)
         self.cache.transforms[visitor.current_document] = visitor.source_transforms
+
+    @staticmethod
+    def merge_environments(app, env, docnames, other):
+        """Merge transform information."""
+        env.sphinx_codeautolink_transforms.update(
+            other.sphinx_codeautolink_transforms
+        )
+
+    def purge_doc_from_environment(self, app, env, docname):
+        """Remove transforms from cache."""
+        if self.cache:
+            self.cache.transforms.pop(docname, None)
 
     @staticmethod
     def make_inventory(app):

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -8,7 +8,7 @@ sess = requests.Session()
 external_site_ids = {}
 
 
-def check_links(root: Path) -> int:
+def check_link_targets(root: Path) -> int:
     """Validate links in HTML site at root, return number of links found."""
     site_docs = {
         p.relative_to(root): BeautifulSoup(p.read_text('utf-8'), 'html.parser')


### PR DESCRIPTION
Related issue: #77

This PR will firstly improve our extension flow. Secondly it will make it safe for parallel execution or failing that, declare that it is not safe.

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
