### PR TITLE
Support ipython directive

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -25,6 +25,8 @@ extensions = [
     "sphinx_codeautolink",
     "matplotlib.sphinxext.plot_directive",
     "sphinx.ext.doctest",
+    "IPython.sphinxext.ipython_directive",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
 
 # Builtin options

--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -219,11 +219,11 @@ However, any test setup and teardown code is not taken into account.
    >>> import lib
    >>> lib.Knight()
 
-IPython code blocks
--------------------
-Code blocks using the language setting ``ipython3`` are supported by default.
+IPython blocks and notebooks
+----------------------------
+Code blocks using ``ipython`` or ``ipython3`` lexers are supported by default.
 The function :func:`~sphinx_codeautolink.clean_ipython` is used to handle
-IPython-specific syntax like so-called `magic functions`_.
+IPython-specific syntax like `magic functions`_ and console prefixes.
 
 .. _magic functions: https://ipython.readthedocs.io/en/stable/
    interactive/tutorial.html#magic-functions
@@ -234,8 +234,18 @@ IPython-specific syntax like so-called `magic functions`_.
    import lib
    lib.Knight().taunt()
 
-This is useful for integrating Jupyter notebooks, which is possible with
-separate Sphinx extensions like nbsphinx_ or MyST-NB_.
+IPython's ``.. ipython::`` `directive <https://ipython.readthedocs.io/en/
+stable/sphinxext.html#>`_ is also supported:
+
+.. ipython::
+
+   In [1]: import lib
+
+   In [2]: lib.Knight().taunt()
+   Out[2]: -taunt here-
+
+They are also useful for integrating Jupyter notebooks and similar source code,
+which is possible with separate Sphinx extensions like nbsphinx_ or MyST-NB_.
 IPython processing is enabled if the ``ipython`` library is installed.
 It is also included in the ``ipython`` extra of sphinx-codeautolink.
 

--- a/docs/src/reference.rst
+++ b/docs/src/reference.rst
@@ -40,6 +40,8 @@ Configuration
    The transformer must return two strings: the code appearing in documentation
    (often just the original source) and the cleaned Python source code.
    The transformer must preserve line numbers for correct matching.
+   The transformer may raise a syntax error, which is caught automatically and
+   a corresponding Sphinx warning using subtype "parsing_error" is issued.
 
 .. confval:: codeautolink_search_css_classes
 

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -14,6 +14,7 @@ Unreleased
 - Link builtins if visible to intersphinx (:issue:`87`)
 - Use Sphinx logging instead of the builtin ``warnings`` to warn
   (:issue:`89`, :issue:`94`)
+- Support IPython's ``.. ipython::`` directive (:issue:`91`)
 
 0.8.0 (2021-12-16)
 ------------------

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -55,9 +55,9 @@ def clean_ipython(source: str) -> Tuple[str, str]:
     in_statement = True
     clean_lines = []
     for line in source.split('\n'):
-        if re.match(r'^In \[[0-9]+\]:\s', line):
+        if re.match(r'^In \[[0-9]+\]: ', line):
             in_statement = True
-        elif re.match(r'^Out\[[0-9]+\]:\s', line):
+        elif re.match(r'^Out\[[0-9]+\]: ', line):
             in_statement = False
         clean_lines.append(line * in_statement)
 

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -49,9 +49,19 @@ BUILTIN_BLOCKS['pycon'] = clean_pycon
 
 
 def clean_ipython(source: str) -> Tuple[str, str]:
-    """Clean up IPython syntax to pure Python."""
+    """Clean up IPython magics and console syntax to pure Python."""
     from IPython.core.inputtransformer2 import TransformerManager
-    return source, TransformerManager().transform_cell(source)
+
+    in_statement = True
+    clean_lines = []
+    for line in source.split('\n'):
+        if re.match(r'^In \[[0-9]+\]:\s', line):
+            in_statement = True
+        elif re.match(r'^Out\[[0-9]+\]:\s', line):
+            in_statement = False
+        clean_lines.append(line * in_statement)
+
+    return source, TransformerManager().transform_cell('\n'.join(clean_lines))
 
 
 try:
@@ -60,6 +70,7 @@ except ImportError:
     pass
 else:
     del IPython
+    BUILTIN_BLOCKS['ipython'] = clean_ipython
     BUILTIN_BLOCKS['ipython3'] = clean_ipython
 
 

--- a/tests/extension/fail/ref_ipython_non-python.txt
+++ b/tests/extension/fail/ref_ipython_non-python.txt
@@ -1,0 +1,12 @@
+extensions.append('IPython.sphinxext.ipython_directive')
+# split
+Test project
+============
+
+.. ipython::
+
+   In [2]: alias bracket echo "Input in brackets <%l>"
+   In [3]: bracket hello world
+   Input in brackets: <hello world>
+
+.. automodule:: test_project

--- a/tests/extension/fail/ref_ipython_syntax.txt
+++ b/tests/extension/fail/ref_ipython_syntax.txt
@@ -1,0 +1,22 @@
+extensions.append('IPython.sphinxext.ipython_directive')
+# split
+Test project
+============
+
+.. ipython::
+   :verbatim:
+
+   In [15]: !wc *
+       2    12    77 README.txt
+      40    97   884 buttons.py
+      26    90   712 check_buttons.py
+      19    52   416 cursor.py
+     180   404  4882 menu.py
+      16    45   337 multicursor.py
+      36   106   916 radio_buttons.py
+      48   226  2082 rectangle_selector.py
+      43   118  1063 slider_demo.py
+      40   124  1088 span_selector.py
+     450  1274 12457 total
+
+.. automodule:: test_project

--- a/tests/extension/ref/ref_ipython3.txt
+++ b/tests/extension/ref/ref_ipython3.txt
@@ -1,0 +1,14 @@
+test_project
+test_project.bar
+# split
+# split
+Test project
+============
+
+.. code:: ipython3
+
+   %cd subdir
+   import test_project
+   test_project.bar()
+
+.. automodule:: test_project

--- a/tests/extension/ref/ref_ipython_directive.txt
+++ b/tests/extension/ref/ref_ipython_directive.txt
@@ -1,17 +1,20 @@
 test_project
 test_project.bar
 # split
+extensions.append('IPython.sphinxext.ipython_directive')
 # split
 Test project
 ============
 
-.. code:: ipython
+.. ipython::
 
-   In [1]: %cd subdir
    In [2]: import test_project
+
    In [3]: b = test_project.bar()
+
    In [4]: 2 + 2
    Out[4]: 4
+
    In [5]: class A:
       ...:     pass
 


### PR DESCRIPTION
Related issue: #91

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed

@OriolAbril could you review this, and particularly comment on your original regex. It had `\s*In\s*[...]\s`, so is there a situation where the notebook has multiple (or other) spaces there? I just used `^In [...] `.

@mgeier you've been involved with the other IPython stuff, so your review would be most helpful too!