### PR TITLE
Add conda forge badge, adjust tox configuration, fix pydocstyle

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,10 +1,11 @@
 sphinx-codeautolink
 ===================
-|pypi| |license|
+|pypi| |conda-forge| |license|
 
 sphinx-codeautolink makes code examples clickable by inserting links
 from individual code elements to the corresponding reference documentation.
 We aim for a minimal setup assuming your examples are already valid Python.
+
 Click any names in the example below for a demonstration:
 
 .. code:: python
@@ -36,9 +37,17 @@ Integration with intersphinx is seamless:
 Quick start
 -----------
 
+For pure Python environments:
+
 .. code:: sh
 
    $ pip install sphinx-codeautolink
+
+Alternatively, for Anaconda-based distributions:
+
+.. code:: sh
+
+   $ conda install -c conda-forge sphinx-codeautolink
 
 To enable sphinx-codeautolink, modify the extension list in ``conf.py``.
 Note that the extension name uses an underscore rather than a hyphen.
@@ -100,11 +109,22 @@ your documentation, you'll not be disappointed in their offer.
    ↪ PyPI <https://pypi.org/project/sphinx-codeautolink>
    ↪ GitHub <https://github.com/felix-hilden/sphinx-codeautolink>
 
-
 .. |pypi| image:: https://img.shields.io/pypi/v/sphinx-codeautolink.svg
    :target: https://pypi.org/project/sphinx-codeautolink
    :alt: PyPI package
 
+.. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/sphinx-codeautolink.svg
+   :target: https://anaconda.org/conda-forge/sphinx-codeautolink
+   :alt: Conda-Forge package
+
 .. |license| image:: https://img.shields.io/badge/License-MIT-blue.svg
    :target: https://choosealicense.com/licenses/mit
    :alt: License: MIT
+
+.. |readthedocs| image:: https://rtfd.org/projects/sphinx-codeautolink/badge/?version=latest
+   :target: https://sphinx-codeautolink.rtfd.org/en/latest/
+   :alt: documentation
+
+.. |build| image:: https://github.com/felix-hilden/sphinx-codeautolink/workflows/CI/badge.svg
+   :target: https://github.com/felix-hilden/sphinx-codeautolink/actions
+   :alt: build status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ python_files = "*.py"
 testpaths = ["tests"]
 
 [tool.coverage.run]
-source = ["src"]
+source = ["sphinx_codeautolink"]
+omit = ["/usr/*"]
 branch = true
 command_line = "-m pytest"
 

--- a/readme.rst
+++ b/readme.rst
@@ -18,7 +18,7 @@ sphinx-codeautolink elsewhere:
 Installation
 ------------
 
-For pure python environments:
+For pure Python environments:
 
 .. code:: sh
 

--- a/readme.rst
+++ b/readme.rst
@@ -1,6 +1,6 @@
 sphinx-codeautolink
 ===================
-|pypi| |license| |readthedocs| |build|
+|pypi| |conda-forge| |license| |readthedocs| |build|
 
 sphinx-codeautolink makes code examples clickable by inserting links
 from individual code elements to the corresponding reference documentation.
@@ -18,9 +18,17 @@ sphinx-codeautolink elsewhere:
 Installation
 ------------
 
+For pure python environments:
+
 .. code:: sh
 
    $ pip install sphinx-codeautolink
+   
+Alternatively, for Anaconda-based distributions:
+
+.. code:: sh
+  
+   $ conda install -c conda-forge sphinx-codeautolink
 
 To enable sphinx-codeautolink, modify the extension list in ``conf.py``.
 Note that the extension name uses an underscore rather than a hyphen.
@@ -40,6 +48,10 @@ have a look at the online documentation.
 .. |pypi| image:: https://img.shields.io/pypi/v/sphinx-codeautolink.svg
    :target: https://pypi.org/project/sphinx-codeautolink
    :alt: PyPI package
+   
+.. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/sphinx-codeautolink.svg
+   :target: https://anaconda.org/conda-forge/sphinx-codeautolink
+   :alt: Conda-Forge package
 
 .. |license| image:: https://img.shields.io/badge/License-MIT-blue.svg
    :target: https://choosealicense.com/licenses/mit

--- a/readme_pypi.rst
+++ b/readme_pypi.rst
@@ -1,6 +1,6 @@
 sphinx-codeautolink
 ===================
-|pyversions| |downloads| |license| |readthedocs|
+|pyversions| |conda-forge| |downloads| |license| |readthedocs|
 
 sphinx-codeautolink makes code examples clickable by inserting links
 from individual code elements to the corresponding reference documentation.
@@ -11,11 +11,17 @@ For a live demo, see our online documentation on
 
 Installation
 ------------
-sphinx-codeautolink can be installed from the Package Index via ``pip``.
+sphinx-codeautolink can be installed from the Python Package Index via ``pip``.
 
 .. code:: sh
 
    $ pip install sphinx-codeautolink
+
+Alternatively, for Anaconda-based distributions, using ``conda``:
+
+.. code:: sh
+
+   $ conda install -c conda-forge sphinx-codeautolink
 
 Note that the library is in early development, so version pinning is advised.
 To enable sphinx-codeautolink, modify the extension list in ``conf.py``.
@@ -36,8 +42,12 @@ have a look at the online documentation.
 .. |pyversions| image:: https://img.shields.io/pypi/pyversions/sphinx-codeautolink
    :alt: Python versions
 
+.. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/sphinx-codeautolink.svg
+   :target: https://anaconda.org/conda-forge/sphinx-codeautolink
+   :alt: Conda-Forge package
+
 .. |downloads| image:: https://img.shields.io/pypi/dm/sphinx-codeautolink
-   :alt: monthly downloads
+   :alt: Monthly downloads
 
 .. |license| image:: https://img.shields.io/badge/License-MIT-blue.svg
    :target: https://choosealicense.com/licenses/mit
@@ -45,4 +55,4 @@ have a look at the online documentation.
 
 .. |readthedocs| image:: https://rtfd.org/projects/sphinx-codeautolink/badge/?version=stable
    :target: https://sphinx-codeautolink.rtfd.org/en/stable/
-   :alt: documentation
+   :alt: Documentation

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
     doc8: doc8
     flake8: flake8
     pydocstyle: pydocstyle
+    pydocstyle: toml
     coverage: coverage
     coverage: pytest-cov
 install_command = python -m pip install --no-user {opts} {packages}
@@ -61,6 +62,7 @@ whitelist_externals =
     doc8
     flake8
     pydocstyle
+    toml
 commands =
     flake8 src tests setup.py
     doc8 docs/src

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = flake8,doc8,pydocstyle,coverage
+opts = -v
 
 [flake8]
 max-line-length = 80
@@ -14,6 +15,16 @@ max-line-length = 80
 [testenv]
 description = Run test suite with pytest
 extras = test
+deps =
+    ipython
+    pytest
+    sphinx
+    doc8: doc8
+    flake8: flake8
+    pydocstyle: pydocstyle
+    coverage: coverage
+    coverage: pytest-cov
+install_command = python -m pip install --no-user {opts} {packages}
 commands = pytest {posargs}
 whitelist_externals = pytest
 
@@ -42,6 +53,10 @@ commands = pydocstyle src
 ; Duplication needed https://github.com/tox-dev/tox/issues/647
 description = Run all static checks
 extras = checks
+deps =
+    doc8
+    flake8
+    pydocstyle
 whitelist_externals =
     doc8
     flake8
@@ -54,5 +69,6 @@ commands =
 [testenv:coverage]
 description = Run test suite with code coverage
 whitelist_externals = coverage
-commands = coverage run
-           coverage report
+commands =
+    coverage run
+    coverage report


### PR DESCRIPTION
<!--
Hi, thanks for submitting a pull request!

This is an example template to start with.
Please write a short summary of your changes and fill in information below.
If some checks don't apply, please check them regardless.
-->

Related issue: #111 

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed

Hey there, this PR does the following:

 - Adds a `conda-forge` badge to a few places in the documentation
 - Adjusts the `pyproject.toml` and `tox` configurations to ensure that `$ tox` runs properly
 - Fixes the code coverage reporting configuration