### PR TITLE
[Doc] Point to concat option

### DIFF
--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -248,6 +248,7 @@ stable/sphinxext.html#>`_ is also supported:
 
 They are also useful for integrating Jupyter notebooks and similar source code,
 which is possible with separate Sphinx extensions like nbsphinx_ or MyST-NB_.
+For use with Jupyter notebooks, it is recommended to enable :confval:`codeautolink_concat_default`.
 IPython processing is enabled if the ``ipython`` library is installed.
 It is also included in the ``ipython`` extra of sphinx-codeautolink.
 

--- a/docs/src/examples.rst
+++ b/docs/src/examples.rst
@@ -248,7 +248,7 @@ stable/sphinxext.html#>`_ is also supported:
 
 They are also useful for integrating Jupyter notebooks and similar source code,
 which is possible with separate Sphinx extensions like nbsphinx_ or MyST-NB_.
-For use with Jupyter notebooks, it is recommended to enable :confval:`codeautolink_concat_default`.
+Enabling :confval:`codeautolink_concat_default` with notebooks is recommended.
 IPython processing is enabled if the ``ipython`` library is installed.
 It is also included in the ``ipython`` extra of sphinx-codeautolink.
 


### PR DESCRIPTION
Jupyter notebooks are almost always made up of multiple cells, the code of which belongs together. Therefore, the concatenation option should be recommended.

This is mainly to save people (like me) a few iterations of wondering why only the first cell in their notebook gets the expected links.
