### PR TITLE
drop python<=3.7 support

### DIFF
--- a/src/sphinx_codeautolink/extension/__init__.py
+++ b/src/sphinx_codeautolink/extension/__init__.py
@@ -184,7 +184,7 @@ class SphinxCodeAutoLink:
                         transform.example
                     )
         if skipped and self.warn_missing_inventory:
-            tops = sorted(set(s.split(".")[0] for s in skipped))
+            tops = sorted({s.split(".")[0] for s in skipped})
             msg = (
                 f"Cannot locate modules: {str(tops)[1:-1]}"
                 "\n  because of missing intersphinx or documentation entries"

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -39,4 +39,4 @@ def check_link_targets(root: Path) -> int:
 
 def gather_ids(soup: BeautifulSoup) -> set:
     """Gather all HTML IDs from a given page."""
-    return set(tag["id"] for tag in soup.find_all(id=True))
+    return {tag["id"] for tag in soup.find_all(id=True)}


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed almost year ago.
Filter all the code over `pyupgrade --py38-plus`.

- [x] Tests written and passed
- [ ] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
