### PR TITLE
Add DIRHTML builder support

### DIFF
--- a/docs/src/about.rst
+++ b/docs/src/about.rst
@@ -16,8 +16,8 @@ is injected after the ordinary Sphinx build is finished.
 
 Caveats
 -------
-- **Only works with HTML or DIRHTML documentation**, disabled otherwise. If the extension
-  is off, it silently removes directives that would produce output.
+- **Only works with HTML or DIRHTML documentation**, disabled otherwise. If the
+  extension is off, it silently removes directives that would produce output.
 - **Only processes blocks, not inline code**. Sphinx has great tools
   for linking definitions inline, and longer code should be in a block anyway.
 - **Doesn't run example code**. Therefore all possible resolvable types are not

--- a/docs/src/about.rst
+++ b/docs/src/about.rst
@@ -16,7 +16,7 @@ is injected after the ordinary Sphinx build is finished.
 
 Caveats
 -------
-- **Only works with HTML documentation**, disabled otherwise. If the extension
+- **Only works with HTML or DIRHTML documentation**, disabled otherwise. If the extension
   is off, it silently removes directives that would produce output.
 - **Only processes blocks, not inline code**. Sphinx has great tools
   for linking definitions inline, and longer code should be in a block anyway.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -68,7 +68,7 @@ Caveats
 -------
 For a more thorough explanation, see :ref:`about`.
 
-- Only works with HTML documentation
+- Only works with HTML or DIRHTML documentation
 - Only processes blocks, not inline code
 - Doesn't run example code
 - Parsing and type hint resolving is incomplete

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,10 @@ These release notes are based on
 sphinx-codeautolink adheres to
 `Semantic Versioning <https://semver.org>`_.
 
+Unreleased
+----------
+- Add support for the DIRHTML Sphinx builder (:issue:`188`)
+
 0.17.2 (2025-03-02)
 -------------------
 - Support :rst:dir:`testsetup` from ``sphinx.ext.doctest`` as another

--- a/src/sphinx_codeautolink/extension/__init__.py
+++ b/src/sphinx_codeautolink/extension/__init__.py
@@ -268,6 +268,7 @@ class SphinxCodeAutoLink:
         visitor = CodeRefsVisitor(
             doctree,
             code_refs=self.code_refs,
+            builder=app.builder.name,
             warn_no_backreference=self.warn_no_backreference,
         )
         doctree.walk(visitor)

--- a/src/sphinx_codeautolink/extension/__init__.py
+++ b/src/sphinx_codeautolink/extension/__init__.py
@@ -89,7 +89,7 @@ class SphinxCodeAutoLink:
     @print_exceptions()
     def build_inited(self, app) -> None:
         """Handle initial setup."""
-        if app.builder.name != "html":
+        if app.builder.name not in ("html", "dirhtml"):
             self.do_nothing = True
             return
 
@@ -289,6 +289,7 @@ class SphinxCodeAutoLink:
                 self.inventory,
                 self.custom_blocks,
                 self.search_css_classes,
+                builder_name=app.builder.name,
             )
 
         self.cache.write()

--- a/src/sphinx_codeautolink/extension/backref.py
+++ b/src/sphinx_codeautolink/extension/backref.py
@@ -63,7 +63,7 @@ class CodeRefsVisitor(nodes.SparseNodeVisitor):
         self,
         *args,
         code_refs: dict[str, list[CodeExample]],
-        builder : str,
+        builder: str,
         warn_no_backreference: bool = False,
         **kwargs,
     ) -> None:

--- a/src/sphinx_codeautolink/extension/backref.py
+++ b/src/sphinx_codeautolink/extension/backref.py
@@ -1,6 +1,7 @@
 """Backreference tables implementation."""
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from docutils import nodes
 
@@ -62,11 +63,13 @@ class CodeRefsVisitor(nodes.SparseNodeVisitor):
         self,
         *args,
         code_refs: dict[str, list[CodeExample]],
+        builder : str,
         warn_no_backreference: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.code_refs = code_refs
+        self.builder = builder
         self.warn_no_backreference = warn_no_backreference
 
     def unknown_departure(self, node) -> None:
@@ -79,7 +82,10 @@ class CodeRefsVisitor(nodes.SparseNodeVisitor):
 
         items = []
         for ref in self.code_refs.get(node.ref, []):
-            link = ref.document + ".html"
+            if self.builder == "dirhtml" and Path(ref.document).name != "index":
+                link = ref.document + "/index.html"
+            else:
+                link = ref.document + ".html"
             if ref.ref_id is not None:
                 link += f"#{ref.ref_id}"
             items.append((link, " / ".join(ref.headings)))

--- a/src/sphinx_codeautolink/extension/block.py
+++ b/src/sphinx_codeautolink/extension/block.py
@@ -375,9 +375,14 @@ def link_html(
     inventory: dict,
     custom_blocks: dict,
     search_css_classes: list,
+    builder_name: str = "html",
 ) -> None:
     """Inject links to code blocks on disk."""
-    html_file = Path(out_dir) / (document + ".html")
+    if builder_name == "dirhtml" and Path(document).name != "index":
+        html_file = Path(out_dir) / document / "index.html"
+    else:
+        html_file = Path(out_dir) / (document + ".html")
+
     text = html_file.read_text("utf-8")
     soup = BeautifulSoup(text, "html.parser")
 

--- a/tests/extension/__init__.py
+++ b/tests/extension/__init__.py
@@ -32,7 +32,6 @@ codeautolink_warn_on_no_backreference = False
 any_whitespace = re.compile(r"\s*")
 ref_tests = [(p.name, p) for p in Path(__file__).with_name("ref").glob("*.txt")]
 ref_xfails = {}
-builders = ["html", "dirhtml"]
 
 
 def assert_links(file: Path, links: list):
@@ -47,8 +46,7 @@ def assert_links(file: Path, links: list):
 
 
 @pytest.mark.parametrize(("name", "file"), ref_tests)
-@pytest.mark.parametrize("builder", builders)
-def test_references(name: str, file: Path, builder: str, tmp_path: Path):
+def test_references(name: str, file: Path, tmp_path: Path):
     """
     Basic extension tests for reference building.
 
@@ -73,7 +71,7 @@ def test_references(name: str, file: Path, builder: str, tmp_path: Path):
 
     files = {"conf.py": default_conf + conf, "index.rst": index}
     print(f"Building file {name}.")
-    result_dir = _sphinx_build(tmp_path, builder, files)
+    result_dir = _sphinx_build(tmp_path, "html", files)
 
     assert_links(result_dir / "index.html", links)
     assert check_link_targets(result_dir) == len(links)
@@ -83,8 +81,7 @@ table_tests = list(Path(__file__).with_name("table").glob("*.txt"))
 
 
 @pytest.mark.parametrize("file", table_tests)
-@pytest.mark.parametrize("builder", builders)
-def test_tables(file: Path, builder: str, tmp_path: Path):
+def test_tables(file: Path, tmp_path: Path):
     """
     Tests for backreference tables.
 
@@ -110,7 +107,7 @@ def test_tables(file: Path, builder: str, tmp_path: Path):
         links = []
 
     files = {"conf.py": default_conf + conf, "index.rst": index}
-    result_dir = _sphinx_build(tmp_path, builder, files)
+    result_dir = _sphinx_build(tmp_path, "html", files)
 
     index_html = result_dir / "index.html"
     text = index_html.read_text("utf-8")
@@ -127,8 +124,7 @@ fail_tests = list(Path(__file__).with_name("fail").glob("*.txt"))
 
 
 @pytest.mark.parametrize("file", fail_tests)
-@pytest.mark.parametrize("builder", builders)
-def test_fails(file: Path, builder: str, tmp_path: Path):
+def test_fails(file: Path, tmp_path: Path):
     """
     Tests for failing builds.
 
@@ -142,7 +138,7 @@ def test_fails(file: Path, builder: str, tmp_path: Path):
     conf, index = file.read_text("utf-8").split("# split")
     files = {"conf.py": default_conf + conf, "index.rst": index}
     with pytest.raises(RuntimeError):
-        _sphinx_build(tmp_path, builder, files)
+        _sphinx_build(tmp_path, "html", files)
 
 
 def test_non_html_build(tmp_path: Path):
@@ -162,8 +158,7 @@ Test project
     _sphinx_build(tmp_path, "man", files)
 
 
-@pytest.mark.parametrize("builder", builders)
-def test_build_twice_and_modify_one_file(builder: str, tmp_path: Path):
+def test_build_twice_and_modify_one_file(tmp_path: Path):
     index = """
 Test project
 ------------
@@ -192,12 +187,11 @@ But edited.
 .. autolink-examples:: test_package.bar
 """
     files = {"conf.py": default_conf, "index.rst": index, "another.rst": another}
-    _sphinx_build(tmp_path, builder, files)
-    _sphinx_build(tmp_path, builder, {"another.rst": another2})
+    _sphinx_build(tmp_path, "html", files)
+    _sphinx_build(tmp_path, "html", {"another.rst": another2})
 
 
-@pytest.mark.parametrize("builder", builders)
-def test_build_twice_and_delete_one_file(builder: str, tmp_path: Path):
+def test_build_twice_and_delete_one_file(tmp_path: Path):
     conf = default_conf + "\nsuppress_warnings = ['toc.not_readable']"
     index = """
 Test project
@@ -221,13 +215,12 @@ Another
 """
 
     files = {"conf.py": conf, "index.rst": index, "another.rst": another}
-    _sphinx_build(tmp_path, builder, files)
+    _sphinx_build(tmp_path, "html", files)
     (tmp_path / "src" / "another.rst").unlink()
-    _sphinx_build(tmp_path, builder, {})
+    _sphinx_build(tmp_path, "html", {})
 
 
-@pytest.mark.parametrize("builder", builders)
-def test_raise_unexpected(builder: str, tmp_path: Path):
+def test_raise_unexpected(tmp_path: Path):
     index = """
 Test project
 ------------
@@ -250,14 +243,13 @@ Test project
 
     target = "sphinx_codeautolink.parse.ImportTrackerVisitor"
     with pytest.raises(RuntimeError), patch(target, raise_msg):
-        _sphinx_build(tmp_path, builder, files)
+        _sphinx_build(tmp_path, "html", files)
 
     with pytest.raises(RuntimeError), patch(target, raise_nomsg):
-        _sphinx_build(tmp_path, builder, files)
+        _sphinx_build(tmp_path, "html", files)
 
 
-@pytest.mark.parametrize("builder", builders)
-def test_parallel_build(builder: str, tmp_path: Path):
+def test_parallel_build(tmp_path: Path):
     index = """
 Test project
 ------------
@@ -282,19 +274,15 @@ Test project
     index = index + "\n   ".join(["", *list(subfiles)])
     files = {"conf.py": default_conf, "index.rst": index}
     files.update({k + ".rst": v for k, v in subfiles.items()})
-    result_dir = _sphinx_build(tmp_path, builder, files, n_processes=4)
+    result_dir = _sphinx_build(tmp_path, "html", files, n_processes=4)
 
     for file in subfiles:
-        if builder == "dirhtml" and file != "index":
-            assert_links(result_dir / file / "index.html", links)
-        else:
-            assert_links(result_dir / (file + ".html"), links)
+        assert_links(result_dir / (file + ".html"), links)
 
     assert check_link_targets(result_dir) == n_subfiles * len(links)
 
 
-@pytest.mark.parametrize("builder", builders)
-def test_skip_identical_code(builder: str, tmp_path: Path):
+def test_skip_identical_code(tmp_path: Path):
     """Code skipped and then linked in an identical block after."""
     index = """
 Test project
@@ -314,7 +302,7 @@ Test project
 .. automodule:: test_project
 """
     files = {"conf.py": default_conf, "index.rst": index}
-    result_dir = _sphinx_build(tmp_path, builder, files)
+    result_dir = _sphinx_build(tmp_path, "html", files)
 
     index_html = result_dir / "index.html"
     text = index_html.read_text("utf-8")

--- a/tests/extension/__init__.py
+++ b/tests/extension/__init__.py
@@ -289,7 +289,7 @@ Test project
             assert_links(result_dir / file / "index.html", links)
         else:
             assert_links(result_dir / (file + ".html"), links)
-            
+
     assert check_link_targets(result_dir) == n_subfiles * len(links)
 
 

--- a/tests/extension/__init__.py
+++ b/tests/extension/__init__.py
@@ -313,6 +313,60 @@ Test project
     assert "sphinx-codeautolink-a" in str(blocks[1])
 
 
+def test_dirhtml_builder(tmp_path: Path):
+    index = """
+Test project
+============
+
+.. toctree::
+   :maxdepth: 2
+
+   page1/index
+   page2
+   subdir/page3
+
+Index Page Code
+---------------
+
+.. code:: python
+
+   import test_project
+   test_project.bar()
+
+.. automodule:: test_project
+"""
+
+    page = """
+Page {idx}
+===========
+
+.. code:: python
+
+   import test_project
+   test_project.bar()
+
+.. autolink-examples:: test_project.bar
+"""
+
+    files = {
+        "conf.py": default_conf,
+        "index.rst": index,
+        "page1/index.rst": page.format(idx=1),
+        "page2.rst": page.format(idx=2),
+        "subdir/page3.rst": page.format(idx=3),
+    }
+    links = ["test_project", "test_project.bar"]
+
+    result_dir = _sphinx_build(tmp_path, "dirhtml", files)
+
+    assert_links(result_dir / "index.html", links)
+    assert_links(result_dir / "page1/index.html", links)
+    assert_links(result_dir / "page2/index.html", links)
+    assert_links(result_dir / "subdir/page3/index.html", links)
+
+    assert check_link_targets(result_dir) == len(links) * 4
+
+
 def _sphinx_build(
     folder: Path, builder: str, files: dict[str, str], n_processes: int | None = None
 ) -> Path:
@@ -320,7 +374,9 @@ def _sphinx_build(
     src_dir = folder / "src"
     src_dir.mkdir(exist_ok=True)
     for name, content in files.items():
-        (src_dir / name).write_text(content, "utf-8")
+        path = src_dir / name
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.write_text(content, "utf-8")
 
     build_dir = folder / "build"
     args = ["-M", builder, str(src_dir), str(build_dir), "-W"]

--- a/tests/extension/__init__.py
+++ b/tests/extension/__init__.py
@@ -32,6 +32,7 @@ codeautolink_warn_on_no_backreference = False
 any_whitespace = re.compile(r"\s*")
 ref_tests = [(p.name, p) for p in Path(__file__).with_name("ref").glob("*.txt")]
 ref_xfails = {}
+builders = ["html", "dirhtml"]
 
 
 def assert_links(file: Path, links: list):
@@ -46,7 +47,8 @@ def assert_links(file: Path, links: list):
 
 
 @pytest.mark.parametrize(("name", "file"), ref_tests)
-def test_references(name: str, file: Path, tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_references(name: str, file: Path, builder: str, tmp_path: Path):
     """
     Basic extension tests for reference building.
 
@@ -71,7 +73,7 @@ def test_references(name: str, file: Path, tmp_path: Path):
 
     files = {"conf.py": default_conf + conf, "index.rst": index}
     print(f"Building file {name}.")
-    result_dir = _sphinx_build(tmp_path, "html", files)
+    result_dir = _sphinx_build(tmp_path, builder, files)
 
     assert_links(result_dir / "index.html", links)
     assert check_link_targets(result_dir) == len(links)
@@ -81,7 +83,8 @@ table_tests = list(Path(__file__).with_name("table").glob("*.txt"))
 
 
 @pytest.mark.parametrize("file", table_tests)
-def test_tables(file: Path, tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_tables(file: Path, builder: str, tmp_path: Path):
     """
     Tests for backreference tables.
 
@@ -107,7 +110,7 @@ def test_tables(file: Path, tmp_path: Path):
         links = []
 
     files = {"conf.py": default_conf + conf, "index.rst": index}
-    result_dir = _sphinx_build(tmp_path, "html", files)
+    result_dir = _sphinx_build(tmp_path, builder, files)
 
     index_html = result_dir / "index.html"
     text = index_html.read_text("utf-8")
@@ -124,7 +127,8 @@ fail_tests = list(Path(__file__).with_name("fail").glob("*.txt"))
 
 
 @pytest.mark.parametrize("file", fail_tests)
-def test_fails(file: Path, tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_fails(file: Path, builder: str, tmp_path: Path):
     """
     Tests for failing builds.
 
@@ -138,7 +142,7 @@ def test_fails(file: Path, tmp_path: Path):
     conf, index = file.read_text("utf-8").split("# split")
     files = {"conf.py": default_conf + conf, "index.rst": index}
     with pytest.raises(RuntimeError):
-        _sphinx_build(tmp_path, "html", files)
+        _sphinx_build(tmp_path, builder, files)
 
 
 def test_non_html_build(tmp_path: Path):
@@ -158,7 +162,8 @@ Test project
     _sphinx_build(tmp_path, "man", files)
 
 
-def test_build_twice_and_modify_one_file(tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_build_twice_and_modify_one_file(builder: str, tmp_path: Path):
     index = """
 Test project
 ------------
@@ -187,11 +192,12 @@ But edited.
 .. autolink-examples:: test_package.bar
 """
     files = {"conf.py": default_conf, "index.rst": index, "another.rst": another}
-    _sphinx_build(tmp_path, "html", files)
-    _sphinx_build(tmp_path, "html", {"another.rst": another2})
+    _sphinx_build(tmp_path, builder, files)
+    _sphinx_build(tmp_path, builder, {"another.rst": another2})
 
 
-def test_build_twice_and_delete_one_file(tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_build_twice_and_delete_one_file(builder: str, tmp_path: Path):
     conf = default_conf + "\nsuppress_warnings = ['toc.not_readable']"
     index = """
 Test project
@@ -215,12 +221,13 @@ Another
 """
 
     files = {"conf.py": conf, "index.rst": index, "another.rst": another}
-    _sphinx_build(tmp_path, "html", files)
+    _sphinx_build(tmp_path, builder, files)
     (tmp_path / "src" / "another.rst").unlink()
-    _sphinx_build(tmp_path, "html", {})
+    _sphinx_build(tmp_path, builder, {})
 
 
-def test_raise_unexpected(tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_raise_unexpected(builder: str, tmp_path: Path):
     index = """
 Test project
 ------------
@@ -243,13 +250,14 @@ Test project
 
     target = "sphinx_codeautolink.parse.ImportTrackerVisitor"
     with pytest.raises(RuntimeError), patch(target, raise_msg):
-        _sphinx_build(tmp_path, "html", files)
+        _sphinx_build(tmp_path, builder, files)
 
     with pytest.raises(RuntimeError), patch(target, raise_nomsg):
-        _sphinx_build(tmp_path, "html", files)
+        _sphinx_build(tmp_path, builder, files)
 
 
-def test_parallel_build(tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_parallel_build(builder: str, tmp_path: Path):
     index = """
 Test project
 ------------
@@ -274,14 +282,19 @@ Test project
     index = index + "\n   ".join(["", *list(subfiles)])
     files = {"conf.py": default_conf, "index.rst": index}
     files.update({k + ".rst": v for k, v in subfiles.items()})
-    result_dir = _sphinx_build(tmp_path, "html", files, n_processes=4)
+    result_dir = _sphinx_build(tmp_path, builder, files, n_processes=4)
 
     for file in subfiles:
-        assert_links(result_dir / (file + ".html"), links)
+        if builder == "dirhtml" and file != "index":
+            assert_links(result_dir / file / "index.html", links)
+        else:
+            assert_links(result_dir / (file + ".html"), links)
+            
     assert check_link_targets(result_dir) == n_subfiles * len(links)
 
 
-def test_skip_identical_code(tmp_path: Path):
+@pytest.mark.parametrize("builder", builders)
+def test_skip_identical_code(builder: str, tmp_path: Path):
     """Code skipped and then linked in an identical block after."""
     index = """
 Test project
@@ -301,7 +314,7 @@ Test project
 .. automodule:: test_project
 """
     files = {"conf.py": default_conf, "index.rst": index}
-    result_dir = _sphinx_build(tmp_path, "html", files)
+    result_dir = _sphinx_build(tmp_path, builder, files)
 
     index_html = result_dir / "index.html"
     text = index_html.read_text("utf-8")

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -27,10 +27,10 @@ def check_link_targets(root: Path) -> int:
                     external_site_ids[base] = gather_ids(sub_soup)
                 ids = external_site_ids[base]
             else:
-                if base == '':
+                if base == "":
                     base = str(doc)
                 elif base == "../":
-                    base = str(doc.parent.parent / 'index.html')
+                    base = str(doc.parent.parent / "index.html")
                 ids = site_ids[Path(base)]
             assert id_ in ids, (
                 f"ID {id_} not found in {base}"

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -27,6 +27,10 @@ def check_link_targets(root: Path) -> int:
                     external_site_ids[base] = gather_ids(sub_soup)
                 ids = external_site_ids[base]
             else:
+                if base == '':
+                    base = str(doc)
+                elif base == "../":
+                    base = str(doc.parent.parent / 'index.html')
                 ids = site_ids[Path(base)]
             assert id_ in ids, (
                 f"ID {id_} not found in {base}"

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -12,7 +12,7 @@ external_site_ids = {}
 def check_link_targets(root: Path) -> int:
     """Validate links in HTML site at root, return number of links found."""
     site_docs = {
-        p.relative_to(root): BeautifulSoup(p.read_text("utf-8"), "html.parser")
+        p: BeautifulSoup(p.read_text("utf-8"), "html.parser")
         for p in root.glob("**/*.html")
     }
     site_ids = {k: gather_ids(v) for k, v in site_docs.items()}
@@ -27,14 +27,18 @@ def check_link_targets(root: Path) -> int:
                     external_site_ids[base] = gather_ids(sub_soup)
                 ids = external_site_ids[base]
             else:
-                if base == "":
-                    base = str(doc)
-                elif base == "../":
-                    base = str(doc.parent.parent / "index.html")
-                ids = site_ids[Path(base)]
+                target_path = (doc.parent / base).resolve()
+                if target_path.is_dir():
+                    target_path /= "index.html"
+                assert target_path.exists(), (
+                    f"Target path {target_path!s} not found while validating"
+                    f" link for `{link.string}` in {doc.relative_to(root)!s}!"
+                )
+                ids = site_ids[target_path]
+
             assert id_ in ids, (
-                f"ID {id_} not found in {base}"
-                f" while validating link for `{link.string}` in {doc!s}!"
+                f"ID {id_} not found in {base} while validating link"
+                f" for `{link.string}` in {doc.relative_to(root)!s}!"
             )
             total += 1
     return total


### PR DESCRIPTION
Adds support the Sphinx `dirhtml` builder, in addition to the `html` builder. 

The `dirhtml` builder builds HTML pages, but with a single directory per document. Makes for prettier URLs (no .html) if served from a webserver.

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
