### PR TITLE
Fix: Use relative URIs for backreference links

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -8,6 +8,10 @@ These release notes are based on
 sphinx-codeautolink adheres to
 `Semantic Versioning <https://semver.org>`_.
 
+Unreleased
+----------
+- Fix backreference links using relative URIs (:issue:`190`)
+
 0.17.3 (2025-03-06)
 -------------------
 - Fix Sphinx InventoryItem deprecation warning (:issue:`173`)

--- a/src/sphinx_codeautolink/extension/__init__.py
+++ b/src/sphinx_codeautolink/extension/__init__.py
@@ -271,7 +271,8 @@ class SphinxCodeAutoLink:
         visitor = CodeRefsVisitor(
             doctree,
             code_refs=self.code_refs,
-            builder=app.builder.name,
+            docname=docname,
+            builder=app.builder,
             warn_no_backreference=self.warn_no_backreference,
         )
         doctree.walk(visitor)

--- a/src/sphinx_codeautolink/extension/backref.py
+++ b/src/sphinx_codeautolink/extension/backref.py
@@ -1,9 +1,9 @@
 """Backreference tables implementation."""
 
 from dataclasses import dataclass
-from pathlib import Path
 
 from docutils import nodes
+from sphinx.builders import Builder
 
 from sphinx_codeautolink.warn import logger, warn_type
 
@@ -63,12 +63,14 @@ class CodeRefsVisitor(nodes.SparseNodeVisitor):
         self,
         *args,
         code_refs: dict[str, list[CodeExample]],
-        builder: str,
+        docname: str,
+        builder: Builder,
         warn_no_backreference: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.code_refs = code_refs
+        self.docname = docname
         self.builder = builder
         self.warn_no_backreference = warn_no_backreference
 
@@ -82,10 +84,7 @@ class CodeRefsVisitor(nodes.SparseNodeVisitor):
 
         items = []
         for ref in self.code_refs.get(node.ref, []):
-            if self.builder == "dirhtml" and Path(ref.document).name != "index":
-                link = ref.document + "/index.html"
-            else:
-                link = ref.document + ".html"
+            link = self.builder.get_relative_uri(self.docname, ref.document)
             if ref.ref_id is not None:
                 link += f"#{ref.ref_id}"
             items.append((link, " / ".join(ref.headings)))

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -43,6 +43,23 @@ def check_link_targets(root: Path) -> int:
             total += 1
     return total
 
+def check_reference_targets_exist(root: Path):
+    site_docs = {
+        p: BeautifulSoup(p.read_text("utf-8"), "html.parser")
+        for p in root.glob("**/*.html")
+    }
+    for doc, soup in site_docs.items():
+        for link in soup.find_all("a", attrs={"class": "reference internal"}):
+            base = link["href"].split("#")[0]
+            if any(base.startswith(s) for s in ("http://", "https://")):
+                continue
+            target_path = doc if base == "" else (doc.parent / base).resolve()
+            if target_path.is_dir():
+                target_path /= "index.html"
+            assert target_path.exists(), (
+                f"Target path {target_path!s} not found while validating"
+                f" link for `{link.string}` in {doc.relative_to(root)!s}!"
+            )
 
 def gather_ids(soup: BeautifulSoup) -> set:
     """Gather all HTML IDs from a given page."""

--- a/tests/extension/_check.py
+++ b/tests/extension/_check.py
@@ -43,6 +43,7 @@ def check_link_targets(root: Path) -> int:
             total += 1
     return total
 
+
 def check_reference_targets_exist(root: Path):
     site_docs = {
         p: BeautifulSoup(p.read_text("utf-8"), "html.parser")
@@ -60,6 +61,7 @@ def check_reference_targets_exist(root: Path):
                 f"Target path {target_path!s} not found while validating"
                 f" link for `{link.string}` in {doc.relative_to(root)!s}!"
             )
+
 
 def gather_ids(soup: BeautifulSoup) -> set:
     """Gather all HTML IDs from a given page."""


### PR DESCRIPTION
Fixes backreference links when the source/target doc are in different folders. Previously these weren't relative, so links "up" or "across" didn't work for both HTML and DIRHTML builders. E.g. the in the `test_html_subdir_reference` test example none of the backreference links to other targets worked on page1 and page2. Adds tests to check that the links are valid. 

- [x] Tests written and passed
- [x] Documentation and changelog entry written, docs build passed
- [x] All `tox` checks passed
