### PR TITLE
Resolve for-loop targets coming from calls returning a hinted iterable

### DIFF
--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -11,6 +11,8 @@ sphinx-codeautolink adheres to
 Unreleased
 ----------
 - Support module attributes and class aliases (:issue:`65`)
+- Resolve for-loop iterables into targets. ``for target in lib.iterable():``
+  now links ``target.method()`` in the loop body (:issue:`196`)
 
 0.17.5 (2025-07-09)
 -------------------

--- a/src/sphinx_codeautolink/extension/resolve.py
+++ b/src/sphinx_codeautolink/extension/resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import abc
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
@@ -13,19 +14,48 @@ from typing import Any, Union, get_type_hints
 
 from sphinx_codeautolink.parse import Name, NameBreak
 
+# Containers whose first generic argument is the element type produced
+# by iteration. ``tuple`` only fits ``tuple[T, ...]``; for mixed tuples
+# like ``tuple[int, str]`` we pick the first arg, which may be wrong.
+ITERABLE_ORIGINS = frozenset(
+    {
+        abc.Iterable,
+        abc.Iterator,
+        abc.Generator,
+        abc.AsyncIterable,
+        abc.AsyncIterator,
+        abc.AsyncGenerator,
+        abc.Collection,
+        abc.Sequence,
+        abc.MutableSequence,
+        abc.Set,
+        abc.MutableSet,
+        abc.Mapping,
+        abc.MutableMapping,
+        list,
+        set,
+        frozenset,
+        tuple,
+        dict,
+    }
+)
+
 
 def resolve_location(chain: Name, inventory) -> str:
     """Find the final type that a name refers to."""
-    segments: list[list[str]] = [[]]
+    segments: list[tuple[list[str], NameBreak | None]] = []
+    current: list[str] = []
     for comp in chain.import_components:
-        if comp == NameBreak.call:
-            segments.append([])
+        if comp in (NameBreak.call, NameBreak.for_iter):
+            segments.append((current, NameBreak(comp)))
+            current = []
         else:
-            segments[-1].append(comp)
+            current.append(comp)
+    segments.append((current, None))
 
     cursor = None
     last = len(segments) - 1
-    for i, segment in enumerate(segments):
+    for i, (segment, terminator) in enumerate(segments):
         comps = segment
         if cursor is None:
             try:
@@ -36,8 +66,10 @@ def resolve_location(chain: Name, inventory) -> str:
                     return ".".join(comps)
                 raise
         cursor = locate_type(cursor, tuple(comps), inventory)
-        if i != last:
+        if terminator == NameBreak.call:
             call_value(cursor)
+        elif terminator == NameBreak.for_iter:
+            iter_value(cursor)
     return cursor.location if cursor is not None else None
 
 
@@ -47,11 +79,12 @@ class CouldNotResolve(Exception):  # noqa: N818
 
 @dataclass
 class Cursor:
-    """Cursor to follow imports, attributes and calls to the final type."""
+    """Cursor to follow a component path to the final type."""
 
     location: str
     value: Any
     instance: bool
+    annotation: Any = None
 
 
 def make_cursor(components: list[str]) -> tuple[list[str], Cursor]:
@@ -78,10 +111,14 @@ def locate_type(cursor: Cursor, components: tuple[str, ...], inventory) -> Curso
                 previous.value = type(previous.value)
                 previous.location = fully_qualified_name(previous.value)
 
+        annotation = None
+        with suppress(NameError, TypeError):
+            annotation = get_type_hints(previous.value).get(component)
         cursor = Cursor(
             previous.location + "." + component,
             getattr(previous.value, component, None),
             previous.instance,
+            annotation=annotation,
         )
 
         if cursor.value is None:
@@ -123,38 +160,68 @@ def call_value(cursor: Cursor) -> None:
     elif not isroutine(cursor.value):
         raise CouldNotResolve  # not a function either
 
-    cursor.value = get_return_annotation(cursor.value)
-    cursor.location = fully_qualified_name(cursor.value)
+    annotation = get_return_annotation(cursor.value)
+    type_ = origin_type(annotation)
+    if not isinstance(type_, type):
+        msg = f"Unable to follow return annotation of {annotation!r}."
+        raise CouldNotResolve(msg)
+    cursor.value = type_
+    cursor.location = fully_qualified_name(type_)
     cursor.instance = True
+    cursor.annotation = annotation
 
 
-def get_return_annotation(func: Callable) -> type | None:
+def iter_value(cursor: Cursor) -> None:
+    """Unwrap the iterable cursor points to into its element type."""
+    element = unwrap_iterable(strip_optional(cursor.annotation))
+    if not isinstance(element, type):
+        msg = (
+            f"Unable to unwrap iterable element type of"
+            f" {get_name_for_debugging(cursor.value)}."
+        )
+        raise CouldNotResolve(msg)
+    cursor.value = element
+    cursor.location = fully_qualified_name(element)
+    cursor.instance = True
+    cursor.annotation = None
+
+
+def strip_optional(annotation: Any) -> Any:
+    """Reduce ``Optional[T]`` / ``T | None`` to ``T``; otherwise return as-is."""
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", None)
+    if (origin is Union or isinstance(annotation, UnionType)) and args:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return annotation
+
+
+def origin_type(annotation: Any) -> Any:
+    """Return underlying type of an annotation (e.g. ``list`` from ``list[Foo]``)."""
+    return getattr(annotation, "__origin__", None) or annotation
+
+
+def unwrap_iterable(annotation: Any) -> type | None:
+    """Return the element type of an iterable annotation, or None."""
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", None)
+    if origin in ITERABLE_ORIGINS and args:
+        return args[0]
+    return None
+
+
+def get_return_annotation(func: Callable) -> Any:
     """Determine the target of a function return type hint."""
     try:
         annotation = get_type_hints(func).get("return")
     except (NameError, TypeError) as e:
         msg = f"Unable to follow return annotation of {get_name_for_debugging(func)}."
         raise CouldNotResolve(msg) from e
-
-    # Inner type from typing.Optional or Union[None, T]
-    origin = getattr(annotation, "__origin__", None)
-    args = getattr(annotation, "__args__", None)
-    if (origin is Union or isinstance(annotation, UnionType)) and len(args) == 2:  # noqa: PLR2004
-        nonetype = type(None)
-        if args[0] is nonetype:
-            annotation = args[1]
-        elif args[1] is nonetype:
-            annotation = args[0]
-
-    if (
-        not annotation
-        or not isinstance(annotation, type)
-        or hasattr(annotation, "__origin__")
-    ):
-        msg = f"Unable to follow return annotation of {get_name_for_debugging(func)}."
+    if not annotation:
+        msg = f"No return annotation on {get_name_for_debugging(func)}."
         raise CouldNotResolve(msg)
-
-    return annotation
+    return strip_optional(annotation)
 
 
 def fully_qualified_name(thing: type | Callable) -> str:

--- a/src/sphinx_codeautolink/parse.py
+++ b/src/sphinx_codeautolink/parse.py
@@ -94,6 +94,7 @@ class NameBreak(str, Enum):
     call = "()"
     namedexpr = ":="
     import_from = ">"
+    for_iter = "<>"
 
 
 class LinkContext(str, Enum):
@@ -499,9 +500,19 @@ class ImportTrackerVisitor(ast.NodeVisitor):
         self.visit_For(node)
 
     def visit_For(self, node: ast.For | ast.AsyncFor) -> None:
-        """Swap node order."""
-        self.visit(node.iter)
-        self.visit(node.target)
+        """Swap node order and resolve iterators."""
+        iter_pending = self.visit(node.iter)
+
+        if (
+            isinstance(iter_pending, PendingAccess)
+            and iter_pending.components
+            and isinstance(node.target, ast.Name)
+        ):
+            marker = Component(NameBreak.for_iter.value, *linenos(node), "load")
+            self.assign_name(node.target.id, [*iter_pending.components, marker])
+        else:
+            self.visit(node.target)
+
         for n in node.body:
             self.visit(n)
         for n in node.orelse:

--- a/tests/extension/ref/ref_for_loop.txt
+++ b/tests/extension/ref/ref_for_loop.txt
@@ -1,0 +1,26 @@
+test_project
+test_project.mod_list
+a.meth
+test_project.mod_typing_list
+b.meth
+test_project.iter_foos
+c.meth
+# split
+# split
+Test project
+============
+
+.. code:: python
+
+   import test_project
+
+   for a in test_project.mod_list:
+       a.meth()
+
+   for b in test_project.mod_typing_list:
+       b.meth()
+
+   for c in test_project.iter_foos():
+       c.meth()
+
+.. automodule:: test_project

--- a/tests/extension/src/test_project/__init__.py
+++ b/tests/extension/src/test_project/__init__.py
@@ -1,5 +1,8 @@
 """Docstring."""
 
+from collections.abc import Iterator
+from typing import List  # noqa: UP035
+
 from .sub import SubBar, subfoo  # noqa: F401
 
 
@@ -34,9 +37,19 @@ mod_int: int = 0
 mod_type = Foo
 """Module attribute whose value is a class, not an instance."""
 
+mod_list: list[Foo] = []
+"""Module list attribute."""
+
+mod_typing_list: List[Foo] = []  # noqa: UP006
+"""Typing module list attribute."""
+
 
 def bar() -> Foo:
     """Bar test function."""
+
+
+def iter_foos() -> "Iterator[Foo]":
+    """Return an iterator of Foos."""
 
 
 def optional() -> Foo | None:

--- a/tests/parse/assign.py
+++ b/tests/parse/assign.py
@@ -298,7 +298,7 @@ class TestAssignLike:
         return s, refs
 
     @refs_equal
-    def test_for_uses_imported(self):
+    def test_for_uses_imported_but_target_unused(self):
         s = "import a\nfor b in a:\n  a"
         refs = [("a", "a"), ("a", "a"), ("a", "a")]
         return s, refs
@@ -312,6 +312,30 @@ class TestAssignLike:
     @refs_equal
     def test_for_uses_and_overwrites_imported(self):
         s = "import a\nfor a in a:\n  a"
+        refs = [("a", "a"), ("a", "a"), ("a.<>", "a")]
+        return s, refs
+
+    @refs_equal
+    def test_for_target_bound_to_iter_name_element(self):
+        s = "import a\nfor b in a:\n  b"
+        refs = [("a", "a"), ("a", "a"), ("a.<>", "b")]
+        return s, refs
+
+    @refs_equal
+    def test_for_target_bound_to_iter_call_element(self):
+        s = "import a\nfor b in a():\n  b"
+        refs = [("a", "a"), ("a", "a"), ("a.().<>", "b")]
+        return s, refs
+
+    @refs_equal
+    def test_for_target_bound_to_iter_attribute_element(self):
+        s = "import a\nfor b in a.x:\n  b"
+        refs = [("a", "a"), ("a.x", "a.x"), ("a.x.<>", "b")]
+        return s, refs
+
+    @refs_equal
+    def test_for_tuple_target_not_bound(self):
+        s = "import a\nfor b, c in a():\n  b"
         refs = [("a", "a"), ("a", "a")]
         return s, refs
 


### PR DESCRIPTION
Hello.

First of all, thanks for this great extension. I have recently integrated it in psutil doc https://github.com/giampaolo/psutil/pull/2826. 

One idiom which is recurring a lot of times in psutil doc is this:

```python
for p in psutil.process_iter(attrs=["name", "status"]):
    print(p.name(), p.status())
```

`sphinx-codeautolink` is not able to resolve `p.name()` and `p.status()`, even if `process_iter` is typed as `-> Iterator[Process]`. This PR makes that possible.

Two small pieces: the parser binds the for-target to the iter chain with a marker when the iter is a function. The resolver unwraps `Iterator[T]` / `Iterable[T]` / `list[T]` etc. to `T` when it sees that marker.

I only handled iter-as-call. `for x in some_var:` still doesn't bind. It would need type inference on the variable.