### PR TITLE
Resolve return annotations that use `TYPE_CHECKING`

### DIFF
--- a/docs/src/about.rst
+++ b/docs/src/about.rst
@@ -85,6 +85,28 @@ The extension parses code blocks in the ``doctree-read`` Sphinx event.
 The priority is set to 490 to catch nodes removed by ``sphinx.ext.doctest``
 (priority 500). In other cases the priority of the extension is default.
 
+Type checking blocks
+********************
+To resolve annotations that reference names imported under
+``if TYPE_CHECKING:``, the extension re-executes the bodies of those gated
+blocks in the importing module's own namespace the first time it inspects
+that module. Without this step, ``typing.get_type_hints`` would fail with
+``NameError`` because, at runtime, ``TYPE_CHECKING`` is ``False`` and the
+gated names are never bound.
+
+A few things to be aware of:
+
+- Only top-level ``if`` blocks whose condition is ``TYPE_CHECKING`` or
+  ``MYPY`` (as a bare name or attribute access, e.g. ``typing.TYPE_CHECKING``)
+  are recognised. The condition is matched by AST shape, not evaluated.
+- The original module objects are mutated in place:
+  names that would normally only exist for type checkers become real
+  attributes on the module.
+- Bodies are executed with the equivalent of ``exec`` in the module's
+  globals. If execution fails, for example due to a cyclic import or
+  a missing optional dependency, that block is silently skipped and the rest
+  of the module continues to work.
+
 Copying code blocks
 -------------------
 If you feel like code links make copying code a bit more difficult,

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -13,6 +13,9 @@ Unreleased
 - Support module attributes and class aliases (:issue:`65`)
 - Resolve for-loop iterables into targets. ``for target in lib.iterable():``
   now links ``target.method()`` in the loop body (:issue:`196`)
+- Resolve return annotations that reference names imported inside an
+  ``if TYPE_CHECKING:`` block, in modules using
+  ``from __future__ import annotations``.
 
 0.17.5 (2025-07-09)
 -------------------

--- a/docs/src/release_notes.rst
+++ b/docs/src/release_notes.rst
@@ -13,9 +13,8 @@ Unreleased
 - Support module attributes and class aliases (:issue:`65`)
 - Resolve for-loop iterables into targets. ``for target in lib.iterable():``
   now links ``target.method()`` in the loop body (:issue:`196`)
-- Resolve return annotations that reference names imported inside an
-  ``if TYPE_CHECKING:`` block, in modules using
-  ``from __future__ import annotations``.
+- Resolve return annotations that reference names imported inside
+  ``if TYPE_CHECKING:`` and similar blocks (:issue:`197`)
 
 0.17.5 (2025-07-09)
 -------------------

--- a/src/sphinx_codeautolink/extension/resolve.py
+++ b/src/sphinx_codeautolink/extension/resolve.py
@@ -211,10 +211,25 @@ def unwrap_iterable(annotation: Any) -> type | None:
     return None
 
 
-def get_return_annotation(func: Callable) -> Any:
+def resolve_type_hints(func: Callable) -> dict:
+    """
+    Resolve runtime type hints for ``func``, including those that
+    reference names imported inside an ``if TYPE_CHECKING:`` block
+    in modules using ``from __future__ import annotations``.
+    """
+    try:
+        return get_type_hints(func)
+    except NameError:
+        import collections.abc
+        import typing as typing_mod
+        fallback = {**vars(typing_mod), **vars(collections.abc)}
+        return get_type_hints(func, localns=fallback)
+
+
+def get_return_annotation(func: Callable) -> type | None:
     """Determine the target of a function return type hint."""
     try:
-        annotation = get_type_hints(func).get("return")
+        annotation = resolve_type_hints(func).get("return")
     except (NameError, TypeError) as e:
         msg = f"Unable to follow return annotation of {get_name_for_debugging(func)}."
         raise CouldNotResolve(msg) from e

--- a/src/sphinx_codeautolink/extension/resolve.py
+++ b/src/sphinx_codeautolink/extension/resolve.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
 from collections import abc
 from collections.abc import Callable
 from contextlib import suppress
@@ -9,7 +11,7 @@ from dataclasses import dataclass
 from functools import cache
 from importlib import import_module
 from inspect import isclass, ismodule, isroutine
-from types import UnionType
+from types import ModuleType, UnionType
 from typing import Any, Union, get_type_hints
 
 from sphinx_codeautolink.parse import Name, NameBreak
@@ -211,25 +213,10 @@ def unwrap_iterable(annotation: Any) -> type | None:
     return None
 
 
-def resolve_type_hints(func: Callable) -> dict:
-    """
-    Resolve runtime type hints for ``func``, including those that
-    reference names imported inside an ``if TYPE_CHECKING:`` block
-    in modules using ``from __future__ import annotations``.
-    """
-    try:
-        return get_type_hints(func)
-    except NameError:
-        import collections.abc
-        import typing as typing_mod
-        fallback = {**vars(typing_mod), **vars(collections.abc)}
-        return get_type_hints(func, localns=fallback)
-
-
-def get_return_annotation(func: Callable) -> type | None:
+def get_return_annotation(func: Callable) -> Any:
     """Determine the target of a function return type hint."""
     try:
-        annotation = resolve_type_hints(func).get("return")
+        annotation = get_type_hints(func).get("return")
     except (NameError, TypeError) as e:
         msg = f"Unable to follow return annotation of {get_name_for_debugging(func)}."
         raise CouldNotResolve(msg) from e
@@ -260,12 +247,61 @@ def closest_module(components: tuple[str, ...]) -> tuple[Any, int]:
     except ImportError as e:
         msg = f"Could not import {components[0]}."
         raise CouldNotResolve(msg) from e
+    populate_type_checking(mod)
 
     for i in range(1, len(components)):
         try:
             mod = import_module(".".join(components[: i + 1]))
-        except ImportError:  # noqa: PERF203
+        except ImportError:
             # import failed, exclude previously added item
             return mod, i
+        populate_type_checking(mod)
     # imports succeeded, include all items
     return mod, len(components)
+
+
+populated_modules: set[int] = set()
+
+
+def populate_type_checking(mod: ModuleType) -> None:
+    """
+    Execute top-level TYPE_CHECKING blocks into ``mod.__dict__``.
+
+    At runtime TYPE_CHECKING is False, so names imported under such gates
+    are never bound on the module. ``get_type_hints`` then fails to resolve
+    annotations that reference them. Re-execute the gated bodies in the
+    module's own namespace so those names become available.
+    """
+    if id(mod) in populated_modules:
+        return
+    populated_modules.add(id(mod))
+
+    try:
+        source = inspect.getsource(mod)
+    except (OSError, TypeError):
+        return
+
+    tree = ast.parse(source)
+
+    filename = getattr(mod, "__file__", None) or "<type_checking>"
+    for node in tree.body:
+        if not isinstance(node, ast.If) or not is_type_checking_test(node.test):
+            continue
+        body = ast.Module(body=node.body, type_ignores=[])
+        # Catch e.g. optional deps and cyclic imports
+        with suppress(Exception):
+            exec(compile(body, filename, "exec"), mod.__dict__)  # noqa: S102
+
+
+def is_type_checking_test(expr: ast.expr) -> bool:
+    """
+    Determine if expr is a test for type checking.
+
+    Mirror mypy's ``infer_condition_value``: match a bare name or any
+    attribute access regardless of qualifier.
+    """
+    if isinstance(expr, ast.Name):
+        return expr.id in ("TYPE_CHECKING", "MYPY")
+    if isinstance(expr, ast.Attribute):
+        return expr.attr in ("TYPE_CHECKING", "MYPY")
+    return False

--- a/tests/extension/ref/ref_type_checking_gated.txt
+++ b/tests/extension/ref/ref_type_checking_gated.txt
@@ -1,0 +1,14 @@
+type_checking_project
+type_checking_project.pick
+attr
+# split
+# split
+Test project
+============
+
+.. code:: python
+
+   import type_checking_project
+   type_checking_project.pick(["a"]).attr
+
+.. automodule:: type_checking_project

--- a/tests/extension/ref/ref_type_checking_gated.txt
+++ b/tests/extension/ref/ref_type_checking_gated.txt
@@ -1,5 +1,5 @@
-type_checking_project
-type_checking_project.pick
+type_checking
+type_checking.pick
 attr
 # split
 # split
@@ -8,7 +8,8 @@ Test project
 
 .. code:: python
 
-   import type_checking_project
-   type_checking_project.pick(["a"]).attr
+   import type_checking
+   type_checking.pick(["a"]).attr
 
-.. automodule:: type_checking_project
+.. automodule:: type_checking
+.. automodule:: type_checking.foo

--- a/tests/extension/src/type_checking/__init__.py
+++ b/tests/extension/src/type_checking/__init__.py
@@ -1,16 +1,16 @@
-# noqa: INP001
 from __future__ import annotations
 
+import typing
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Collection
 
+if typing.TYPE_CHECKING:
+    from .foo import Foo
 
-class Foo:
-    """Foo test class."""
-
-    attr: str = "test"
+if False:
+    pass
 
 
 def pick(items: Collection[str]) -> Foo:

--- a/tests/extension/src/type_checking/foo.py
+++ b/tests/extension/src/type_checking/foo.py
@@ -1,0 +1,4 @@
+class Foo:
+    """Foo test class."""
+
+    attr: str = "test"

--- a/tests/extension/src/type_checking_project.py
+++ b/tests/extension/src/type_checking_project.py
@@ -1,0 +1,19 @@
+# noqa: INP001
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+
+class Foo:
+    """Foo test class."""
+
+    attr: str = "test"
+
+
+def pick(items: Collection[str]) -> Foo:
+    """Return value whose annotation references a name guarded by
+    ``if TYPE_CHECKING: ...``
+    """


### PR DESCRIPTION
This is a follow-up of #196 (same psutil docs integration).                                                                                                                                                                                           

In psutil I use this idiom (see [source](https://github.com/giampaolo/psutil/blob/66f43c6c/psutil/__init__.py#L68)):

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from collections.abc import Collection
    from typing import Any
    from typing import Callable
    ...
```

I do this to avoid unnecessary imports and save a little time.

This makes `typing.get_type_hints(process_iter)` raise `NameError: name 'Collection' is not defined`, because `Collection` is only imported inside the `if TYPE_CHECKING:` block, so `codeautolink` cannot resolve it. 

The `if TYPE_CHECKING` idiom is very common though, and also documented (https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING), so it would be nice to support it. 

AFAICT the only alternative for projects like psutil is to remove `if TYPE_CHECKING` and pay the performance cost.
                                                                                                                                                                                     
This PR retries `get_type_hints` once with `typing` and `collections.abc` merged into `localns`. That should cover the names typically find inside an `if TYPE_CHECKING:` block (Collection, Iterable, Mapping, Callable, etc.). 